### PR TITLE
Increased megamag exp reward, reduced armor a little

### DIFF
--- a/server/js/properties.js
+++ b/server/js/properties.js
@@ -201,16 +201,16 @@ var Properties = {
             burger: 100
         },
         hp: 15000,
-        armor: 50,
+        armor: 40,
         weapon: 8,
         aoe: {
             damage: 100,
             range: 2
         },
         redpacket: true,
-        xp: 10000,  
+        xp: 50000,  
         expMultiplier: {
-            duration: 900
+            duration: 1800
         },
         messages: ['Perish!', 'Be gone!', 'Burn!', 'Wither!', 'Suffer!']
     }


### PR DESCRIPTION
- Reduced the armor a little, 50 could be too much considering the big hp regen
- Increased exp reward and double exp duration on kill. Whereas 50k seems justified considering the difficulty, 30 min double exp may need to be reduced down in the future once the players learn to deal with him and kill him consistently