### PR TITLE
Speed weapon pvp disable

### DIFF
--- a/client/js/character.js
+++ b/client/js/character.js
@@ -559,7 +559,7 @@ define(['entity', 'transition', 'timer'], function(Entity, Transition, Timer) {
                 return;
             }
             else if (this.attackCooldown !== undefined && this.attackCooldown.duration !== rate) {
-                this.attackCooldown = new Timer(rate);
+                this.attackCooldown.duration = rate;
             }
         },
 

--- a/client/js/game.js
+++ b/client/js/game.js
@@ -3526,6 +3526,7 @@ function(InfoManager, BubbleManager, Renderer, Mapx, Animation, Sprite, Animated
                 var isMoving = this.tryMovingToADifferentTile(character); // Don't let multiple mobs stack on the same tile when attacking a player.
                 
                 if(character.canAttack(time)) {
+                    console.log(Date.now() + " Reset timer");
                     if(!isMoving) { // don't hit target if moving to a different tile.
                         if(character.hasTarget() && character.getOrientationTo(character.target) !== character.orientation) {
                             character.lookAtTarget();
@@ -3535,14 +3536,22 @@ function(InfoManager, BubbleManager, Renderer, Mapx, Animation, Sprite, Animated
                         
                         if(character.id === this.playerId) {
                             this.client.sendHit(character.target);
+                            console.log(Date.now() + " Hit");
                         }
                         
                         if(character instanceof Player && this.camera.isVisible(character)) {
                             this.audioManager.playSound("hit"+Math.floor(Math.random()*2+1));
                         }
-                        
-                        if(character.hasTarget() && character.target.id === this.playerId && this.player && !this.player.invincible) {
+
+                        console.log(character.hasTarget());
+                        console.log(character.target.id === this.playerId);
+                        console.log(this.player);
+                        console.log(!this.player.invincible);
+                        console.log(!(character instanceof Player));
+
+                        if(character.hasTarget() && character.target.id === this.playerId && this.player && !this.player.invincible & !(character instanceof Player)) {
                             this.client.sendHurt(character);
+                            console.log(Date.now() + " Hurt");
                         }
                     }
                 } else {

--- a/client/js/game.js
+++ b/client/js/game.js
@@ -3526,7 +3526,6 @@ function(InfoManager, BubbleManager, Renderer, Mapx, Animation, Sprite, Animated
                 var isMoving = this.tryMovingToADifferentTile(character); // Don't let multiple mobs stack on the same tile when attacking a player.
                 
                 if(character.canAttack(time)) {
-                    console.log(Date.now() + " Reset timer");
                     if(!isMoving) { // don't hit target if moving to a different tile.
                         if(character.hasTarget() && character.getOrientationTo(character.target) !== character.orientation) {
                             character.lookAtTarget();
@@ -3536,22 +3535,14 @@ function(InfoManager, BubbleManager, Renderer, Mapx, Animation, Sprite, Animated
                         
                         if(character.id === this.playerId) {
                             this.client.sendHit(character.target);
-                            console.log(Date.now() + " Hit");
                         }
                         
                         if(character instanceof Player && this.camera.isVisible(character)) {
                             this.audioManager.playSound("hit"+Math.floor(Math.random()*2+1));
                         }
 
-                        console.log(character.hasTarget());
-                        console.log(character.target.id === this.playerId);
-                        console.log(this.player);
-                        console.log(!this.player.invincible);
-                        console.log(!(character instanceof Player));
-
                         if(character.hasTarget() && character.target.id === this.playerId && this.player && !this.player.invincible & !(character instanceof Player)) {
                             this.client.sendHurt(character);
-                            console.log(Date.now() + " Hurt");
                         }
                     }
                 } else {

--- a/server/js/player.js
+++ b/server/js/player.js
@@ -186,12 +186,11 @@ module.exports = Player = Character.extend({
                 var mob = self.server.getEntityById(message[1]);
 
                 if(mob) {
+                    let newAttackRate = BASE_ATTACK_RATE;
+                    
                     if (mob instanceof Player) {
                         mob.handleHurt(self);
                     } else {
-                        // reset attack speed so if it is increased via the trait it will be reset if a weapon with it is not equiped
-                        self.setAttackRate(BASE_ATTACK_RATE);
-
                         let level = self.getLevel();
                         let totalLevel = (self.getWeaponLevel() + level) - 1;
 
@@ -235,13 +234,16 @@ module.exports = Player = Character.extend({
                         } else if (weaponTrait === "crit") {
                             handleDamage(mob, totalLevel, 3);
                         } else if (weaponTrait === "speed") {
-                            self.setAttackRate(self.getAttackRate() - (25 * self.getWeaponLevel()));
                             handleDamage(mob, totalLevel, 1);
+                            newAttackRate = BASE_ATTACK_RATE - (25 * self.getWeaponLevel());
                         } else {
                             handleDamage(mob, totalLevel, 1);
                         }
                     }
 
+                    if (newAttackRate != self.getAttackRate()){
+                        self.setAttackRate(newAttackRate);
+                    }
                 }
             }
             else if(action === Types.Messages.HURT) {


### PR DESCRIPTION
- Fixed speed weapon working in PvP if a mob was engaged before combat
- Fixed damage in PvP being doubled: one player reported damage dealt and the other player reported damage taken
- Minor setAttackRate related refactors