### PR TITLE
Added support for optional "_left" animations.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ config_local*
 configs/*
 nft_template/sqlscript.sql
 *Zone.Identifier
+.idea

--- a/client/js/character.js
+++ b/client/js/character.js
@@ -71,21 +71,32 @@ define(['entity', 'transition', 'timer'], function(Entity, Transition, Timer) {
     	animate: function(animation, speed, count, onEndCount) {
     	    var oriented = ['atk', 'walk', 'idle'];
     	        o = this.orientation;
-            
-            if(!(this.currentAnimation && this.currentAnimation.name === "death") // don't change animation if the character is dying
-                && !(this.currentAnimation && this.currentAnimation.name === "special" && this.animationLock)) { // don't change animation if the character is doing a special
-            	this.flipSpriteX = false;
-        	    this.flipSpriteY = false;
-	    
-        	    if(_.indexOf(oriented, animation) >= 0) {
-        	        animation += "_" + (o === Types.Orientations.LEFT ? "right" : Types.getOrientationAsString(o));
-        	        this.flipSpriteX = (this.orientation === Types.Orientations.LEFT) ? true : false;
-        	    }
 
-        		this.setAnimation(animation, speed, count, onEndCount);
-        	}
+            // don't change animation if the character is dying
+            if(this.currentAnimation && this.currentAnimation.name === "death") {
+                return;
+            }
+
+            // don't change animation if the character is doing a special
+            if(this.currentAnimation && this.currentAnimation.name === "special" && this.animationLock) {
+                return
+            }
+
+            this.flipSpriteX = false;
+            this.flipSpriteY = false;
+
+            if(_.indexOf(oriented, animation) >= 0) {
+                if(o === Types.Orientations.LEFT && !this.hasAnimation(animation + '_' + Types.getOrientationAsString(o))) {
+                    animation += "_right";
+                    this.flipSpriteX = true
+                } else {
+                    animation += "_" + Types.getOrientationAsString(o);
+                }
+            }
+
+            this.setAnimation(animation, speed, count, onEndCount);
     	},
-    
+
         turnTo: function(orientation) {
             this.orientation = orientation;
             this.idle();

--- a/client/js/entity.js
+++ b/client/js/entity.js
@@ -72,7 +72,7 @@ define(function() {
     	    return this.sprite;
     	},
 	
-    	getSpriteName: function() {
+    	getSpriteName: function() {
     	    return Types.getKindAsString(this.kind);
     	},
 	
@@ -87,7 +87,11 @@ define(function() {
             }
             return animation;
         },
-    
+
+        hasAnimation: function(name) {
+            return (name in this.animations);
+        },
+
     	setAnimation: function(name, speed, count, onEndCount) {
     	    var self = this;
 	    


### PR DESCRIPTION
This update allows characters to have an optional `"walk_left"`, `"idle_left"` and `"atk_left"` animation configured in the spite.json flie for a specific character located in `client/sprites/*.json`.

By adding a `hasAnimation` check we are making sure this doesn't break the current sprites.
An example sprite's `.json` file is shown below:
```json
{
  "id": "NFT_c33674c027dfba62462683bc2c10108aa0daf9a1426ed3a72a4e7992cb1ae761",
  "width": 32,
  "height": 32,
  "animations": {
    "atk_right": {
      "length": 5,
      "row": 0
    },
    "walk_right": {
      "length": 4,
      "row": 1
    },
    "idle_right": {
      "length": 2,
      "row": 2
    },
    "atk_up": {
      "length": 5,
      "row": 3
    },
    "walk_up": {
      "length": 4,
      "row": 4
    },
    "idle_up": {
      "length": 2,
      "row": 5
    },
    "atk_down": {
      "length": 5,
      "row": 6
    },
    "walk_down": {
      "length": 4,
      "row": 7
    },
    "idle_down": {
      "length": 2,
      "row": 8
    },
    "walk_left": {
      "length": 4,
      "row": 9
    },
    "atk_left": {
      "length": 5,
      "row": 10
    },
    "idl_left": {
      "length": 2,
      "row": 11
    }
  },
  "offset_x": -8,
  "offset_y": -12
}
```
The matching sprite must be extended with 3 new rows in this case.