### PR TITLE
Cobsfarm ghostiefix 08 26 2023

### DIFF
--- a/client/js/game.js
+++ b/client/js/game.js
@@ -3037,6 +3037,14 @@ function(InfoManager, BubbleManager, Renderer, Mapx, Animation, Sprite, Animated
                         mob.doSpecial();
                     }
                 });
+
+                self.client.onMobExitCombat(function(id) {
+                    let mob = self.getEntityById(id);
+
+                    if (typeof mob.exitCombat === 'function') {
+                        mob.exitCombat();
+                    }
+                });
             
                 self.gamestart_callback();
             

--- a/client/js/game.js
+++ b/client/js/game.js
@@ -2236,7 +2236,7 @@ function(InfoManager, BubbleManager, Renderer, Mapx, Animation, Sprite, Animated
                     self.forEachMob(function(mob) {
                         if(mob.isAggressive 
                         && (!mob.isFriendly || mob.breakFriendly(self.player)) 
-                        && !mob.isAttacking() 
+                        && !mob.inCombat 
                         && self.player.isNear(mob, mob.aggroRange)) 
                         {
                             self.player.aggro(mob);
@@ -2251,6 +2251,7 @@ function(InfoManager, BubbleManager, Renderer, Mapx, Animation, Sprite, Animated
                             self.createBubble(mob.id, mob.aggroMessage);
                             self.assignBubbleTo(mob);
                         }
+                        mob.joinCombat();
                         self.client.sendAggro(mob);
                         mob.waitToAttack(self.player);
                     }
@@ -4150,6 +4151,13 @@ function(InfoManager, BubbleManager, Renderer, Mapx, Animation, Sprite, Animated
                             if (toUpdateEntity.moveSpeed !== undefined && toUpdateEntity.attackRate !== undefined) {
                                 self.entities[id].moveSpeed = toUpdateEntity.moveSpeed;
                                 self.entities[id].setAttackRate(toUpdateEntity.attackRate);
+                            }
+                            if (toUpdateEntity.inCombat !== undefined) {
+                                if (!self.entities[id].inCombat && toUpdateEntity.inCombat){
+                                    self.entities[id].joinCombat();
+                                } else if (self.entities[id].inCombat && !toUpdateEntity.inCombat) {
+                                    self.entities[id].exitCombat();
+                                }
                             }
                         } else {
                             console.debug("Unknown entity " + id);

--- a/client/js/gameclient.js
+++ b/client/js/gameclient.js
@@ -37,6 +37,7 @@ define(['player', 'entityfactory', 'lib/bison'], function(Player, EntityFactory,
             this.handlers[Types.Messages.HP] = this.receiveHitPoints;
             this.handlers[Types.Messages.BLINK] = this.receiveBlink;
             this.handlers[Types.Messages.MOBDOSPECIAL] = this.receiveMobDoSpecial;
+            this.handlers[Types.Messages.MOBEXITCOMBAT] = this.receiveMobExitCombat;
         
             this.useBison = false;
             this.enable();
@@ -383,6 +384,14 @@ define(['player', 'entityfactory', 'lib/bison'], function(Player, EntityFactory,
                 this.mobDoSpecial_callback(id);
             }
         },
+
+        receiveMobExitCombat: function(data) {
+            var id = data[1];
+        
+            if(this.mobExitCombat_callback) {
+                this.mobExitCombat_callback(id);
+            }
+        },
         
         onDispatched: function(callback) {
             this.dispatched_callback = callback;
@@ -478,6 +487,10 @@ define(['player', 'entityfactory', 'lib/bison'], function(Player, EntityFactory,
 
         onMobDoSpecial: function(callback) {
             this.mobDoSpecial_callback = callback;
+        },
+
+        onMobExitCombat: function(callback) {
+            this.mobExitCombat_callback = callback;
         },
 
         sendHello: function(player) {

--- a/client/js/mob.js
+++ b/client/js/mob.js
@@ -7,6 +7,7 @@ define(['character'], function(Character) {
         
             this.aggroRange = 1;
             this.isAggressive = true;
+            this.inCombat = false;
 
             this.animationLock = false;
             this.nameOffsetY = -10;
@@ -14,6 +15,14 @@ define(['character'], function(Character) {
 
         breakFriendly: function(){
             return;
+        },
+
+        joinCombat: function() {
+            this.inCombat = true;
+        },
+
+        exitCombat: function() {
+            this.inCombat = false;
         }
     });
     

--- a/client/js/mobs.js
+++ b/client/js/mobs.js
@@ -436,7 +436,7 @@ define(['mob', 'timer'], function(Mob, Timer) {
             },
 
             breakFriendly: function(player) {
-                if (this.isFriendly && this.isNear(player, 2) && !this.disengaging){
+                if (this.isFriendly && this.isNear(player, 2) && !this.exitingCombat){
                     this.isFriendly = false;
                     this.setVisible(true);
                     this.fadeIn(new Date().getTime());
@@ -445,17 +445,13 @@ define(['mob', 'timer'], function(Mob, Timer) {
                 return false;
             },
 
-            disengage: function() {
+            exitCombat: function() {
                 let self = this;
-
-                this.attackingMode = false;
-                this.followingMode = false;
-                this.removeTarget();
                 this.isFriendly = true;
                 
-                this.disengaging = setTimeout(function() {
+                this.exitingCombat = setTimeout(function() {
                     self.setVisible(false);
-                    self.disengaging = null;
+                    self.exitingCombat = null;
                 }, 1000)  
             }
         }),

--- a/client/js/mobs.js
+++ b/client/js/mobs.js
@@ -435,24 +435,36 @@ define(['mob', 'timer'], function(Mob, Timer) {
                 this.aggroMessage = "Boo!";
             },
 
+            appear: function() {
+                this.isFriendly = false;
+                this.setVisible(true);
+                this.fadeIn(new Date().getTime());
+            },
+
             breakFriendly: function(player) {
-                if (this.isFriendly && this.isNear(player, 2) && !this.exitingCombat){
-                    this.isFriendly = false;
-                    this.setVisible(true);
-                    this.fadeIn(new Date().getTime());
+                if (this.isFriendly && this.isNear(player, this.aggroRange - 1) && !this.exitingCombat) {
+                    this.appear()
                     return true;
                 }
                 return false;
             },
 
+            joinCombat: function() {
+                this._super();
+                if (this.inCombat && this.isFriendly) {
+                    this.appear();
+                }
+            },
+
             exitCombat: function() {
+                this._super();
                 let self = this;
                 this.isFriendly = true;
                 
                 this.exitingCombat = setTimeout(function() {
                     self.setVisible(false);
                     self.exitingCombat = null;
-                }, 1000)  
+                }, 1500)  
             }
         }),
     };

--- a/server/js/character.js
+++ b/server/js/character.js
@@ -102,5 +102,9 @@ module.exports = Character = Entity.extend({
 
     getWeaponLevel: function () {
         return this.weaponLevel;
-    }
+    },
+
+    isInCombat: function() {
+        return;
+    },
 });

--- a/server/js/message.js
+++ b/server/js/message.js
@@ -219,3 +219,13 @@ Messages.MobDoSpecial = Message.extend({
                 this.mob.id];
     }
 });
+
+Messages.MobExitCombat = Message.extend({
+    init: function(mob) {
+        this.mob = mob;
+    },
+    serialize: function() {
+        return [Types.Messages.MOBEXITCOMBAT,
+                this.mob.id];
+    }
+});

--- a/server/js/mob.js
+++ b/server/js/mob.js
@@ -171,6 +171,7 @@ module.exports = Mob = Character.extend({
         this.returnTimeout = setTimeout(function() {
             self.resetPosition();
             self.move(self.x, self.y);
+            self.exitCombat();
         }, delay);
     },
     
@@ -196,5 +197,15 @@ module.exports = Mob = Character.extend({
     clearSpecialInterval: function() {
         clearInterval(this.specialInterval);
         this.specialInterval = null;
+    },
+
+    onExitCombat: function(callback) {
+        this.exitCombat_callback = callback;
+    },
+
+    exitCombat: function() {
+        if(this.exitCombat_callback) {
+            this.exitCombat_callback(this);
+        }
     }
 });

--- a/server/js/mob.js
+++ b/server/js/mob.js
@@ -207,5 +207,9 @@ module.exports = Mob = Character.extend({
         if(this.exitCombat_callback) {
             this.exitCombat_callback(this);
         }
-    }
+    },
+
+    isInCombat: function() {
+        return this.hatelist.length > 0 ? true : false;
+    },
 });

--- a/server/js/mobarea.js
+++ b/server/js/mobarea.js
@@ -27,6 +27,7 @@ module.exports = MobArea = Area.extend({
             mob = new Mob('1' + this.id + ''+ k + ''+ this.entities.length, k, pos.x, pos.y);
         
         mob.onMove(this.world.onMobMoveCallback.bind(this.world));
+        mob.onExitCombat(this.world.onMobExitCombatCallback.bind(this.world));
 
         return mob;
     },

--- a/server/js/worldserver.js
+++ b/server/js/worldserver.js
@@ -647,6 +647,7 @@ module.exports = World = cls.Class.extend({
                     }
                 });
                 mob.onMove(self.onMobMoveCallback.bind(self));
+                mob.onExitCombat(self.onMobExitCombatCallback.bind(self));
                 self.addMob(mob);
                 self.tryAddingMobToChestArea(mob);
             }
@@ -1097,6 +1098,10 @@ module.exports = World = cls.Class.extend({
             this.doorTriggers[triggerId] = false;
             console.log("Trigger " + triggerId + " deactivated!");
         }
+    },
+
+    onMobExitCombatCallback: function(mob) {
+        this.pushToAdjacentGroups(mob.group, new Messages.MobExitCombat(mob));
     }
 
 });

--- a/server/js/worldserver.js
+++ b/server/js/worldserver.js
@@ -956,7 +956,8 @@ module.exports = World = cls.Class.extend({
                     maxHitPoints: entity.maxHitPoints,
                     hitPoints: entity.hitPoints,
                     moveSpeed: entity.getMoveSpeed(),
-                    attackRate: entity.getAttackRate()
+                    attackRate: entity.getAttackRate(),
+                    inCombat: entity.isInCombat()
                 } 
             }
         }

--- a/shared/js/gametypes.js
+++ b/shared/js/gametypes.js
@@ -29,7 +29,8 @@ Types = {
         OPEN: 25,
         CHECK: 26,
         EQUIP_INVENTORY: 27,
-        MOBDOSPECIAL: 28
+        MOBDOSPECIAL: 28,
+        MOBEXITCOMBAT: 29,
     },
     
     Entities: {


### PR DESCRIPTION
- Added client side inCombat mob flag (for now only mob, players aren't tracked)
- Added combat state to server polling info, call client side joinCombat and exitCombat on state change
- Added mobExitCombat server to client message. I'm not entirely happy with that, as this information is already polled, but polling only occurs on entity attack and entity respawn. I found that when a player simply runs away, no polling occurs cause no attacks occur, therefore the mob wouldn't really exit combat. If sending an extra message is a concern for server efficiency then I'm up to reverting this though