### PR TITLE
Aoe on hit property

### DIFF
--- a/server/js/fieldeffect.js
+++ b/server/js/fieldeffect.js
@@ -10,7 +10,7 @@ module.exports = Fieldeffect = Entity.extend({
 
     initDamageCallback: function(callback) {
         const self = this;
-        kindString = Types.getKindAsString(this.kind);
+        let kindString = Types.getKindAsString(this.kind);
 
         if (Properties[kindString] !== undefined && Properties[kindString].aoe !== undefined){
             self.damage_callback = callback;

--- a/server/js/player.js
+++ b/server/js/player.js
@@ -264,7 +264,19 @@ module.exports = Player = Character.extend({
             }
             else if(action === Types.Messages.HURT) {
                 var mob = self.server.getEntityById(message[1]);
-                self.handleHurt(mob);
+
+                if (mob instanceof Mob){
+                    let kindString = Types.getKindAsString(mob.kind);
+                    let aoeProps = Properties[kindString].aoe;
+
+                    if (aoeProps !== undefined && aoeProps.onHit) {
+                        self.server.doAoe(mob);
+                    } else {
+                        self.handleHurt(mob);
+                    }
+                } else {
+                    self.handleHurt(mob);
+                }
             }
             else if(action === Types.Messages.LOOT) {
                 var item = self.server.getEntityById(message[1]);

--- a/server/js/properties.js
+++ b/server/js/properties.js
@@ -313,7 +313,7 @@ var Properties = {
         },
         aoe: {
             damage: 60,
-            ondeath: true
+            onDeath: true
         },
         armorMod: 2,
         weaponMod: 0.8
@@ -367,7 +367,13 @@ var Properties = {
             cobcorn: 10
         },
         armorMod: 0.75,
-        hpMod: 0.75
+        hpMod: 0.75,
+        aoe: {
+            damage: 10,
+            range: 3,
+            onHit: true,
+            onDeath: true
+        }
     },
 
     cobslimered: {

--- a/server/js/properties.js
+++ b/server/js/properties.js
@@ -367,13 +367,7 @@ var Properties = {
             cobcorn: 10
         },
         armorMod: 0.75,
-        hpMod: 0.75,
-        aoe: {
-            damage: 10,
-            range: 3,
-            onHit: true,
-            onDeath: true
-        }
+        hpMod: 0.75
     },
 
     cobslimered: {

--- a/server/js/worldserver.js
+++ b/server/js/worldserver.js
@@ -610,7 +610,7 @@ module.exports = World = cls.Class.extend({
                 this.pushToGroup(mob.group, mob.despawn());
                 //On death AoE handling
                 let aoeProps = Properties[kind].aoe;
-                if (aoeProps !== undefined && aoeProps.ondeath) {
+                if (aoeProps !== undefined && aoeProps.onDeath) {
                     this.doAoe(mob);
                 }
                 


### PR DESCRIPTION
Added an option to replace mobs regular hits with an aoe cleave.
2 potential issues:
1. AoE is a bit unreliable currently, as the server randomizes mobs position around the player on server side, but client side the mob follows the shortest pathing. Therefore to a server a mob is in a different place than it is to a player, which results in the AoE being initiated from a "seemingly wrong tile". A bandaid fix to that is to make aoe range big enough (at least 2-3 tiles), where this doesnt matter much. I advise against making aoe with a range 1 for now; until the server-client sync gets updated a little
2. The onHit Aoe happens on player reporting hurt to the server. If a player gets somehow timed out/lagged, I imagine nobody will take the the aoe damage at all. Same happens currently though - a lagged out player is technically immortal.
---
Also refactored onDeath to be consistent with capital letter usage + fixed an unitialized variable typo in field effects (though it did work properly somehow?)