### PR TITLE
Allow multi-line quests start messages.

### DIFF
--- a/client/js/game.js
+++ b/client/js/game.js
@@ -3829,12 +3829,24 @@ function(InfoManager, BubbleManager, Renderer, Mapx, Animation, Sprite, Animated
         checkForQuests: function(npc) {
             let self = this;
             let url = '/session/' + self.sessionId + '/npc/' + npc.kind;
+            if(npc.thoughts.length > 0) {
+                let message = npc.thoughts.shift()
+                self.createBubble(npc.id, message);
+                self.assignBubbleTo(npc);
+                self.audioManager.playSound("npc");
+                return;
+            }
             axios.get(url).then(function (response) {
                 if (response.data !== "") {
-                    self.createBubble(npc.id, response.data);
+                    let messages  = (!_.isArray(response.data) ? [response.data] : response.data);
+
+                    let message = messages.shift()
+                    npc.addThoughts( messages );
+                    self.createBubble(npc.id, message);
                     self.assignBubbleTo(npc);
-                    self.audioManager.playSound("npc"); 
+                    self.audioManager.playSound("npc");
                     self.showNotification("Quest Accepted");
+
                 } else {
                     msg = npc.talk();
                     self.previousClickPosition = {};

--- a/client/js/npc.js
+++ b/client/js/npc.js
@@ -293,6 +293,7 @@ define(['character'], function (Character) {
             this.itemKind = Types.getKindAsString(this.kind);
             this.talkCount = NpcTalk[this.itemKind].length;
             this.talkIndex = 0;
+            this.thoughts = [];
         },
 
         talk: function () {
@@ -307,6 +308,13 @@ define(['character'], function (Character) {
             this.talkIndex += 1;
 
             return msg;
+        },
+
+        addThoughts: function(messages) {
+            // add elements from messages array to thoughts array
+            for (var i = 0; i < messages.length; i++) {
+                this.thoughts.push(messages[i]);
+            }
         }
     });
 

--- a/server/js/ws.js
+++ b/server/js/ws.js
@@ -385,7 +385,7 @@ WS.socketIOServer = Server.extend({
                         availableQuests.push({
                             id: quest.id,
                             name: quest.name,
-                            desc: quest.startText,
+                            desc: quest.questLogText ?? quest.startText,
                             medal: quest.medal,
                             amount: quest.amount,
                             status: "COMPLETED"


### PR DESCRIPTION
Allow multi-line quests start messages.
By setting an array of strings to the startText property of a quest instead of a string.
This should be combined with the new "questLogText" property to control what's being displayed in the quest-log.

example:

```
{
    id: "KING_QUEST_50",
    name: "King's ratatouille",
    startText: ["Hi!", "I've got a quest for you.", "Kill 50 rats!", ".... O, wait! ....", "...", "Don't get killed!"],
    questLogText: "Kill 50 rats",
    endText: "Thanks for killing the rats",
    eventType: "KILL_MOB",
    npc: Types.Entities.KING,
    target: Types.Entities.RAT,
    amount: 10000,
    level: 1,
    medal: Types.Medals.RAT
}
 ```