### PR TITLE
Respawn lvl offset fix

### DIFF
--- a/server/js/mob.js
+++ b/server/js/mob.js
@@ -10,15 +10,10 @@ module.exports = Mob = Character.extend({
     init: function(id, kind, x, y) {
         this._super(id, "mob", kind, x, y);
 
-        this.level = Properties.getLevel(this.kind);
-        this.levelOffset = Math.round(Formulas.gaussianRangeRandom(-0.2 * this.level, 0.2 * this.level));
-        this.level += this.levelOffset;
-
-        this.updateHitPoints();
+        this.generateLevel();
+        this.recalculateStats();
         this.spawningX = x;
         this.spawningY = y;
-        this.armorLevel = Properties.getArmorLevel(this.kind, this.levelOffset);
-        this.weaponLevel = Properties.getWeaponLevel(this.kind, this.levelOffset);
         this.hatelist = [];
         this.respawnTimeout = null;
         this.returnTimeout = null;
@@ -234,4 +229,17 @@ module.exports = Mob = Character.extend({
         }
     },
 
+    generateLevel: function() {
+        let deviation = 0.2;
+
+        this.level = Properties.getLevel(this.kind);
+        this.levelOffset = Math.round(Formulas.gaussianRangeRandom(-deviation * this.level, deviation * this.level));
+        this.level += this.levelOffset;
+    },
+
+    recalculateStats: function() {
+        this.updateHitPoints();
+        this.armorLevel = Properties.getArmorLevel(this.kind, this.levelOffset);
+        this.weaponLevel = Properties.getWeaponLevel(this.kind, this.levelOffset);
+    }
 });

--- a/server/js/mob.js
+++ b/server/js/mob.js
@@ -230,7 +230,7 @@ module.exports = Mob = Character.extend({
     },
 
     generateLevel: function() {
-        let deviation = 0.2;
+        const deviation = 0.2;
 
         this.level = Properties.getLevel(this.kind);
         this.levelOffset = Math.round(Formulas.gaussianRangeRandom(-deviation * this.level, deviation * this.level));

--- a/server/js/mobarea.js
+++ b/server/js/mobarea.js
@@ -43,6 +43,8 @@ module.exports = MobArea = Area.extend({
             mob.x = pos.x;
             mob.y = pos.y;
             mob.isDead = false;
+            mob.generateLevel();
+            mob.recalculateStats();
             self.addToArea(mob);
             self.world.addMob(mob);
         }, delay);

--- a/server/js/worldserver.js
+++ b/server/js/worldserver.js
@@ -676,6 +676,8 @@ module.exports = World = cls.Class.extend({
                 var mob = new Mob('7' + kind + count++, kind, pos.x + 1, pos.y);
                 mob.onRespawn(function() {
                     mob.isDead = false;
+                    mob.generateLevel();
+                    mob.recalculateStats();
                     self.addMob(mob);
                     if(mob.area && mob.area instanceof ChestArea) {
                         mob.area.addToArea(mob);


### PR DESCRIPTION
Fixed level offset mechanic - now the level also randomizes upon respawn (before it was only randomizing upon mob creation). This was the intended behavior but somehow I havent noticed that during testing