### PR TITLE
disabled double exp on megamag kill

### DIFF
--- a/server/js/properties.js
+++ b/server/js/properties.js
@@ -361,10 +361,7 @@ var Properties = {
             range: 2
         },
         redpacket: true,
-        xp: 50000,  
-        expMultiplier: {
-            duration: 1200
-        },
+        xp: 50000,
         messages: ['Perish!', 'Be gone!', 'Burn!', 'Wither!', 'Suffer!'],
         respawnDelay: 1800000
     },


### PR DESCRIPTION
Megamag can now be soloed apparently, so double EXP is way too op