### PR TITLE
fixed default weapon sprite

### DIFF
--- a/client/sprites/sword1.json
+++ b/client/sprites/sword1.json
@@ -1,1 +1,45 @@
-{	"id": "sword1",	"width": 32,	"height": 32,	"animations": {		"atk_right": {			"length": 5,			"row": 0		},		"walk_right": {			"length": 4,			"row": 1		},		"idle_right": {			"length": 2,			"row": 2		},		"atk_up": {			"length": 5,			"row": 3		},		"walk_up": {			"length": 4,			"row": 4		},		"idle_up": {			"length": 2,			"row": 5		},		"atk_down": {			"length": 5,			"row": 6		},		"walk_down": {			"length": 4,			"row": 7		},		"idle_down": {			"length": 2,			"row": 8		}	},	"offset_x": -8,	"offset_y": -12}
+{
+	"id": "sword1",
+	"width": 48,
+	"height": 48,
+	"animations": {
+		"atk_right": {
+			"length": 5,
+			"row": 0
+		},
+		"walk_right": {
+			"length": 4,
+			"row": 1
+		},
+		"idle_right": {
+			"length": 2,
+			"row": 2
+		},
+		"atk_up": {
+			"length": 5,
+			"row": 3
+		},
+		"walk_up": {
+			"length": 4,
+			"row": 4
+		},
+		"idle_up": {
+			"length": 2,
+			"row": 5
+		},
+		"atk_down": {
+			"length": 5,
+			"row": 6
+		},
+		"walk_down": {
+			"length": 4,
+			"row": 7
+		},
+		"idle_down": {
+			"length": 2,
+			"row": 8
+		}
+	},
+	"offset_x": -16,
+	"offset_y": -20
+}


### PR DESCRIPTION
Every now and then for one reason or another, a player spawns with the default dagger as a weapon (or any new looper).
The default sword sprite was an absolute mess  - seems like it was a copied file from a looper 32x32 sample (rather than weapon 48x48 sample)