### PR TITLE
fix to not dying during special animation

### DIFF
--- a/client/js/character.js
+++ b/client/js/character.js
@@ -78,7 +78,7 @@ define(['entity', 'transition', 'timer'], function(Entity, Transition, Timer) {
             }
 
             // don't change animation if the character is doing a special
-            if(this.currentAnimation && this.currentAnimation.name === "special" && this.animationLock) {
+            if(animation !== "death" && this.currentAnimation && this.currentAnimation.name === "special" && this.animationLock) {
                 return
             }
 


### PR DESCRIPTION
fix to a random bug i found - apparently the dying itself is dependant on getting to finish the animation, therefore death animation can never be stopped and should always have a priority