### PR TITLE
Mob heal and friendly on exit combat

### DIFF
--- a/client/js/mob.js
+++ b/client/js/mob.js
@@ -23,7 +23,15 @@ define(['character','../../shared/js/altnames','../../shared/js/gametypes'], fun
         },
 
         exitCombat: function() {
+            let self = this;
+
             this.inCombat = false;
+            this.isFriendly = true;
+ 
+            this.exitingCombat = setTimeout(function() {
+                self.isFriendly = false;
+                self.exitingCombat = null;
+            }, 4000)  
         },
 
         initAltName: function (){

--- a/client/js/mobs.js
+++ b/client/js/mobs.js
@@ -1796,10 +1796,9 @@ define(['mob', 'timer'], function(Mob, Timer) {
             },
 
             exitCombat: function() {
-                this._super();
                 let self = this;
                 this.isFriendly = true;
-                
+                this.inCombat = false;
                 this.exitingCombat = setTimeout(function() {
                     self.setVisible(false);
                     self.exitingCombat = null;
@@ -1864,23 +1863,6 @@ define(['mob', 'timer'], function(Mob, Timer) {
                         self.idle();
                     });
             },
-
-            exitCombat: function() {
-                this._super();
-                let self = this;
-                this.isFriendly = true;
-                /* Currently when mob exits combat (eg. out of range from spawn) he can INSTANTLY aggro back, 
-                which creates all sort of weird behaviours. For example you can kite a mob endlessly out of his area (25 tiles),
-                as long, as you move away slowly and never exceed the aggro range. This will make the mob aggro you instantly after un-aggroing
-                but at the same time reset his arrays, such as hatelist, dmgTakenArray, addsArray etc.
-                In my opinion the code below should be a default behavior for every single mob (think mob evading in WoW), and should eventually
-                be moved to _super. For now its here for "test purposes"*/    
-                this.exitingCombat = setTimeout(function() {
-                    self.isFriendly = false;
-                    self.exitingCombat = null;
-                }, 4000)  
-            }
-            
         }),
 
         Cobcat: Mob.extend({

--- a/server/js/worldserver.js
+++ b/server/js/worldserver.js
@@ -1204,6 +1204,7 @@ module.exports = World = cls.Class.extend({
         this.pushToAdjacentGroups(mob.group, new Messages.MobExitCombat(mob));
         mob.clearSpecialInterval();
         this.despawnAllAdds(mob);
+        mob.resetHitPoints(mob.maxHitPoints);
     },
 
     spawnMobAdd: function(parent, childKind, x, y) {


### PR DESCRIPTION
Moves Cob Slime King test reset behavior to a default, global mob method. Now when a mob exits combat it will become immune and friendly for 4 seconds while it returns to its spawn point. This was tested on cob slime king for over a month and seems to be doing OK

Additionally, during exit combat mobs will heal back to full HP