### PR TITLE
let server have full control over mob being in combat

### DIFF
--- a/client/js/game.js
+++ b/client/js/game.js
@@ -3928,7 +3928,6 @@ function(InfoManager, BubbleManager, Renderer, Mapx, Animation, Sprite, Animated
                             self.createBubble(mob.id, mob.aggroMessage);
                             self.assignBubbleTo(mob);
                         }
-                        mob.joinCombat();
                         self.client.sendAggro(mob);
                         mob.waitToAttack(self.player);
                     }


### PR DESCRIPTION
Join/Exit combat is entirely dependant on server messages now.
There (potentially, it was hard to reproduce) was an issue, where a client executed a joinCombat on aggro, but 0.1 sec later received "not inCombat" polling from the server. This caused the mob to exit combat.

After these changes the decision of combat state is 100% on the server side. This may cause some mobs (for example ghosties) to behave weirdly when there's a delay between server-client comms, essentially atacking a player while being invisible (for the duration of the server/client delay), but well... lag is lag, hard to play around it