### PR TITLE
fixed some minor issues

### DIFF
--- a/client/js/game.js
+++ b/client/js/game.js
@@ -6286,6 +6286,7 @@ function(InfoManager, BubbleManager, Renderer, Mapx, Animation, Sprite, Animated
                     const waitMin = 6000,
                           waitMax = 12000;
                     let waitDuration = Math.random() * (waitMax - waitMin) + waitMin;
+                    clearTimeout(self.uniFishTimeout);
                     self.uniFishTimeout = setTimeout(function() {
                         self.playCatchFish(response.data.fish, response.data.difficulty, response.data.speed);
                     }, waitDuration);                    
@@ -6310,8 +6311,10 @@ function(InfoManager, BubbleManager, Renderer, Mapx, Animation, Sprite, Animated
             this.fishingData.fishTime = new Date().getTime();
             this.app.setFish(fishSpriteUrl);
             this.generateFishingTarget(difficulty);
+            clearInterval(this.slidingFish);
             this.slidingFish = setInterval(self.tickMovingFish.bind(self), 10, speed);
             this.app.showFishing();
+            clearTimeout(self.uniFishTimeout);
             this.uniFishTimeout = setTimeout(function() {
                 self.showNotification(self.fishingData.fishName + " escaped!");
                 self.stopFishing(false);

--- a/server/js/player.js
+++ b/server/js/player.js
@@ -189,6 +189,11 @@ module.exports = Player = Character.extend({
                 }
             }
             else if(action === Types.Messages.HIT) {
+                let nftWeapon = self.getNFTWeapon();
+                if (nftWeapon !== undefined && !(nftWeapon instanceof NFTWeapon.NFTWeapon)){
+                    return;
+                }
+
                 var mob = self.server.getEntityById(message[1]);
 
                 if(mob) {
@@ -436,7 +441,7 @@ module.exports = Player = Character.extend({
                     }
                 }
             } else if(action === Types.Messages.FISHINGRESULT) {
-                if (message[1]) {
+                if (message[1] && self.pendingFish !== null) {
                     self.incrementNFTSpecialItemExperience(self.pendingFish.exp);
                     self.playerEventBroker.lootEvent({kind: self.pendingFish.name});
                 }


### PR DESCRIPTION
Fixed 2 issues that the discord bot was reporting:
1. Somebody managed to attack with a fishing rod equipped. Server-client was out of sync => client side they had a regular weapon equipped, but server side it was still a fishing rod. How did this happen? I've got no idea, but now we check server side if it's an NFTWeapon. If it's not, then we quit the function (player would deal 0 damage in this case, but that would happen either way when client<>server is out of sync like that
2. Fixed an issue where server tries to award exp from succesfull fish catch, but pending fish is null. I'm assuming this happens, when the fishing timeout (failure) happens exactly at the same time as the user clicks, and the server gets a fishing failed + fishing succesfull messages both essentially at the same time (failure first).